### PR TITLE
fix: resolve diagnostics AttributeError by correctly mapping coordinator state

### DIFF
--- a/custom_components/hdg_boiler/const.py
+++ b/custom_components/hdg_boiler/const.py
@@ -98,7 +98,7 @@ __all__: Final[list[str]] = [
     "POLLING_GROUP_DEFINITIONS",
 ]
 
-__version__: Final[str] = "1.2.5"
+__version__: Final[str] = "1.2.7"
 
 # --------------------------------------------------------------------------------
 # Compatibility Shims


### PR DESCRIPTION
Updated diagnostics.py to access coordinator data via the internal '_polling_state' dictionary and properties instead of non-existent attributes. This prevents an AttributeError/HTTP 500 when downloading diagnostics, ensuring robust data retrieval even when certain state attributes are not directly available on the coordinator instance.